### PR TITLE
Cache an exception result when retrieving config values

### DIFF
--- a/src/main/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplier.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/supplier/ConfigValueSupplier.kt
@@ -18,15 +18,18 @@ package org.jitsi.metaconfig.supplier
 
 import org.jitsi.metaconfig.ConfigException
 import org.jitsi.metaconfig.Deprecation
+import org.jitsi.metaconfig.util.ConfigResult
+import org.jitsi.metaconfig.util.getOrThrow
+import org.jitsi.metaconfig.util.resultOf
 
 /**
  * A [ConfigValueSupplier] is a class which is responsible for retrieving the value
  * of a configuration property.
  */
 abstract class ConfigValueSupplier<ValueType : Any> {
-    private val value: ValueType by lazy { doGet() }
+    private val value: ConfigResult<ValueType> by lazy { resultOf { doGet() } }
 
-    fun get(): ValueType = value
+    fun get(): ValueType = value.getOrThrow()
 
     /**
      * Apply a [Deprecation] to this [ConfigValueSupplier].  Deprecation is only applied to types

--- a/src/main/kotlin/org/jitsi/metaconfig/util/ConfigResult.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/util/ConfigResult.kt
@@ -25,7 +25,7 @@ sealed class ConfigResult<out T> {
     class Failure(val exception: Throwable) : ConfigResult<Nothing>()
 }
 
-fun <T> ConfigResult<T>.getOrThrow(): T = when(this) {
+fun <T> ConfigResult<T>.getOrThrow(): T = when (this) {
     is ConfigResult.Success<T> -> value
     is ConfigResult.Failure -> throw exception
 }

--- a/src/main/kotlin/org/jitsi/metaconfig/util/ConfigResult.kt
+++ b/src/main/kotlin/org/jitsi/metaconfig/util/ConfigResult.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.metaconfig.util
+
+/**
+ * A simplified version of kotlin's [Result], which has issues when returned from
+ * a lambda (https://youtrack.jetbrains.com/issue/KT-27586).
+ */
+sealed class ConfigResult<out T> {
+    class Success<out T>(val value: T) : ConfigResult<T>()
+    class Failure(val exception: Throwable) : ConfigResult<Nothing>()
+}
+
+fun <T> ConfigResult<T>.getOrThrow(): T = when(this) {
+    is ConfigResult.Success<T> -> value
+    is ConfigResult.Failure -> throw exception
+}
+
+inline fun <T> resultOf(block: () -> T): ConfigResult<T> {
+    return try {
+        ConfigResult.Success(block())
+    } catch (t: Throwable) {
+        ConfigResult.Failure(t)
+    }
+}

--- a/src/test/kotlin/org/jitsi/metaconfig/ConfigPropertyBuildingTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/ConfigPropertyBuildingTest.kt
@@ -130,5 +130,42 @@ class ConfigPropertyBuildingTest : ShouldSpec({
             }
             obj.num shouldBe null
         }
+        should("cache the result if the inner suppliers of an optionalconfig throw") {
+            var callCount = 0
+            val obj = object {
+                val num: Int? by optionalconfig {
+                    "test" {
+                        callCount++
+                        throw NullPointerException()
+                    }
+                }
+            }
+            obj.num shouldBe null
+            obj.num shouldBe null
+            obj.num shouldBe null
+            callCount shouldBe 1
+        }
+
+        should("cache the result if the inner suppliers of a config throw") {
+            var callCount = 0
+            val obj = object {
+                val num: Int by config {
+                    "test" {
+                        callCount++
+                        throw NullPointerException()
+                    }
+                }
+            }
+            shouldThrow<Throwable> {
+                obj.num
+            }
+            shouldThrow<Throwable> {
+                obj.num
+            }
+            shouldThrow<Throwable> {
+                obj.num
+            }
+            callCount shouldBe 1
+        }
     }
 })

--- a/src/test/kotlin/org/jitsi/metaconfig/util/ConfigResultTest.kt
+++ b/src/test/kotlin/org/jitsi/metaconfig/util/ConfigResultTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.metaconfig.util
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class ConfigResultTest : ShouldSpec({
+    context("resultOf") {
+        should("return success if the block succeeds") {
+            resultOf { 42 }.shouldBeInstanceOf<ConfigResult.Success<Int>>()
+        }
+        should("return failure if the block throws") {
+            resultOf { throw NullPointerException() }.shouldBeInstanceOf<ConfigResult.Failure>()
+        }
+    }
+    context("getOrThrow") {
+        should("return the value if the block succeeds") {
+            resultOf { 42 }.getOrThrow() shouldBe 42
+        }
+        should("throw if the block throws") {
+            shouldThrow<NullPointerException> {
+                resultOf<Int> { throw NullPointerException() }.getOrThrow()
+            }
+        }
+    }
+})


### PR DESCRIPTION
`ConfigValueSupplier` caches the result of the retrieval so we don't re-run the retrieval code on every access, but if the `ConfigValueSuppler#doGet` chain throws, we bubble the exception up: a `ConfigDelegate` propagates the exception all the way up and an `OptionalConfigDelegate` catches it and returns null.  This behavior, though, breaks the caching in `ConfigValueSupplier` as `lazy` doesn't cache the exception.

This PR adds a `ConfigResult` class (which is a very simplified version of kotlin's `Result`, which still has issues) in which we can store the result of retrieval--be it a value or an exception.